### PR TITLE
Fix Object ID format to be compatible to ECS Atmos

### DIFF
--- a/EsuApiLib/MetadataList.cs
+++ b/EsuApiLib/MetadataList.cs
@@ -1,4 +1,4 @@
-// Copyright ?2008, EMC Corporation.
+﻿// Copyright © 2022, EMC Corporation.
 // Redistribution and use in source and binary forms, with or without modification, 
 // are permitted provided that the following conditions are met:
 //

--- a/EsuApiLib/MetadataList.cs
+++ b/EsuApiLib/MetadataList.cs
@@ -1,4 +1,4 @@
-// Copyright © 2008, EMC Corporation.
+// Copyright ?2008, EMC Corporation.
 // Redistribution and use in source and binary forms, with or without modification, 
 // are permitted provided that the following conditions are met:
 //
@@ -33,6 +33,8 @@ namespace EsuApiLib {
     /// </summary>
     public class MetadataList : IEnumerable<Metadata> {
         private Dictionary<string, Metadata> meta;
+        private Nullable<int> expirationPeriod;
+        private Nullable<int> retentionPeriod;
 
         /// <summary>
         /// Creates a new MetadataList
@@ -68,6 +70,38 @@ namespace EsuApiLib {
         /// <returns>The item count</returns>
         public int Count() {
             return meta.Count;
+        }
+
+        /// <summary>
+        /// Set Expiration Period
+        /// </summary>
+        public void setExpirationPeriod(int period)
+        {
+            expirationPeriod = period;
+        }
+
+        /// <summary>
+        /// Get Expiration Period
+        /// </summary>
+        public Nullable<int> getExpirationPeriod()
+        {
+            return expirationPeriod;
+        }
+
+        /// <summary>
+        /// Set Retention Period
+        /// </summary>
+        public void setRetentionPeriod(int period)
+        {
+            retentionPeriod = period;
+        }
+
+        /// <summary>
+        /// Get Retention Period
+        /// </summary>
+        public Nullable<int> getRetentionPeriod()
+        {
+            return retentionPeriod;
         }
 
         /// <summary>

--- a/EsuApiLib/ObjectId.cs
+++ b/EsuApiLib/ObjectId.cs
@@ -37,7 +37,7 @@ namespace EsuApiLib {
         /// <summary>
         /// The regular expression that checks whether identifiers are valid.
         /// </summary>
-        private static readonly Regex ID_FORMAT = new Regex("^[0-9a-f]{44,}$");
+        private static readonly Regex ID_FORMAT = new Regex("^[0-9a-f-]{44,}$");
 
         private string id;
 

--- a/EsuApiLib/Rest/EsuRestApi.cs
+++ b/EsuApiLib/Rest/EsuRestApi.cs
@@ -3885,17 +3885,17 @@ namespace EsuApiLib.Rest {
                     }
                     listable.Append( formatTag( meta ) );
                 } else {
-                    if (meta.Name == "x-emc-expiration-period" || meta.Name == "x-emc-retention-period") {
-                        headers.Add(meta.Name, meta.Value);
-                    } else {
-                        if (nonListable.Length > 0)
-                        {
-                            nonListable.Append(", ");
-                        }
-                        nonListable.Append(formatTag(meta));
+                    if( nonListable.Length > 0 ) {
+                        nonListable.Append( ", " );
                     }
+                    nonListable.Append( formatTag( meta ) );
                 }
             }
+            
+            if( metadata.getExpirationPeriod() != null )
+                headers.Add( "x-emc-expiration-period", metadata.getExpirationPeriod().Value.ToString() );
+            if (metadata.getRetentionPeriod() != null)
+                headers.Add( "x-emc-retention-period", metadata.getRetentionPeriod().Value.ToString() );
 
             // Only set the headers if there's data
             if( listable.Length > 0 ) {

--- a/EsuApiLib/Rest/EsuRestApi.cs
+++ b/EsuApiLib/Rest/EsuRestApi.cs
@@ -47,7 +47,7 @@ namespace EsuApiLib.Rest {
     /// safely in a multithreaded environment. 
     /// </summary>
     public class EsuRestApi : EsuApi {
-        private static readonly Regex OBJECTID_EXTRACTOR = new Regex( "/[0-9a-zA-Z]+/objects/([0-9a-f]{44,})" );
+        private static readonly Regex OBJECTID_EXTRACTOR = new Regex( "/[0-9a-zA-Z]+/objects/([0-9a-f-]{44,})" );
         private static TraceSource log = new TraceSource("EsuRestApi");
         private static Encoding headerEncoder = Encoding.GetEncoding("iso-8859-1");
 

--- a/EsuApiLib/Rest/EsuRestApi.cs
+++ b/EsuApiLib/Rest/EsuRestApi.cs
@@ -3885,10 +3885,15 @@ namespace EsuApiLib.Rest {
                     }
                     listable.Append( formatTag( meta ) );
                 } else {
-                    if( nonListable.Length > 0 ) {
-                        nonListable.Append( ", " );
+                    if (meta.Name == "x-emc-expiration-period" || meta.Name == "x-emc-retention-period") {
+                        headers.Add(meta.Name, meta.Value);
+                    } else {
+                        if (nonListable.Length > 0)
+                        {
+                            nonListable.Append(", ");
+                        }
+                        nonListable.Append(formatTag(meta));
                     }
-                    nonListable.Append( formatTag( meta ) );
                 }
             }
 

--- a/EsuApiTest/EsuApiTest.cs
+++ b/EsuApiTest/EsuApiTest.cs
@@ -2195,13 +2195,13 @@ namespace EsuApiLib {
         }
 
         /// <summary>
-        /// x-emc-expiration-period only works on ECS Atmos
+        /// Setting expiration-period only works on ECS Atmos
         /// </summary>
         [TestMethod()]
         public void testECSExpirationPeriod()
         {
             MetadataList mlist = new MetadataList();
-            mlist.AddMetadata(new Metadata("x-emc-expiration-period", "5", false));
+            mlist.setExpirationPeriod(5);
             ObjectId id = this.esu.CreateObject(null, mlist, Encoding.UTF8.GetBytes("Test expiration-period"), "text/plain");
             Assert.IsNotNull(id, "null ID returned");
 
@@ -2224,13 +2224,13 @@ namespace EsuApiLib {
         }
 
         /// <summary>
-        /// x-emc-retention-period only works on ECS Atmos
+        /// Setting retention-period only works on ECS Atmos
         /// </summary>
         [TestMethod()]
         public void testECSRetentionPeriod()
         {
             MetadataList mlist = new MetadataList();
-            mlist.AddMetadata(new Metadata("x-emc-retention-period", "5", false));
+            mlist.setRetentionPeriod(5);
             ObjectId id = this.esu.CreateObject(null, mlist, Encoding.UTF8.GetBytes("Test expiration-period"), "text/plain");
             Assert.IsNotNull(id, "null ID returned");
 

--- a/EsuApiTest/EsuApiTest.csproj
+++ b/EsuApiTest/EsuApiTest.csproj
@@ -65,7 +65,6 @@
     <None Include="EsuApiTest.exe.config">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
-    <Shadow Include="Test References\EsuApiLib.accessor" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\EsuApiLib\EsuApiLib.csproj">

--- a/EsuApiTest/Test References/EsuApiLib.accessor
+++ b/EsuApiTest/Test References/EsuApiLib.accessor
@@ -1,2 +1,0 @@
-EsuApiLib.dll
-Desktop


### PR DESCRIPTION
1. Fix EsuApiTest build failure in VS2019.
2. Fix Object ID format to be compatible to ECS Atmos.
3. Added support for retention/expiration period header.